### PR TITLE
read summary

### DIFF
--- a/src/energiapy/model/sets/components.py
+++ b/src/energiapy/model/sets/components.py
@@ -1,0 +1,38 @@
+from ...components.scenario import Scenario
+from ...utils.scale_utils import scale_pyomo_set
+from pyomo.environ import ConcreteModel, Set
+
+
+def generate_component_sets(instance: ConcreteModel, scenario: Scenario):
+    """generates sets for components
+    1. resources 
+    2. processes and processes_full (containing storage charge and discharge processes)
+    3. materials
+    4. locations
+    5. transport
+
+    Args:
+        instance (ConcreteModel): pyomo model
+        scenario (Scenario): energiapy scenario
+    """
+
+    sets = scenario.set_dict
+
+    instance.resources = Set(
+        initialize=sets['resources'], doc='Set of resources')
+
+    instance.processes = Set(
+        initialize=sets['processes'], doc='Set of processes')
+    instance.processes_full = Set(initialize=sets['processes_full'],
+                                  doc='Set of all processes including dummy discharge')
+
+    if len(scenario.material_set) > 0:
+        instance.materials = Set(
+            initialize=sets['materials'], doc='Set of materials')
+
+    instance.locations = Set(
+        initialize=sets['locations'], doc='Set of locations')
+
+    if scenario.transport_set is not None:
+        instance.transports = Set(
+            initialize=sets['transports'], doc='Set of transports')

--- a/src/energiapy/model/sets/location_subsets.py
+++ b/src/energiapy/model/sets/location_subsets.py
@@ -1,0 +1,21 @@
+from ...components.scenario import Scenario
+from ...utils.scale_utils import scale_pyomo_set
+from pyomo.environ import ConcreteModel, Set
+
+
+def generate_location_subsets(instance: ConcreteModel, scenario: Scenario):
+    """generates location subsets
+
+    Args:
+        instance (ConcreteModel): pyomo model
+        scenario (Scenario): energiapy scenario
+    """
+
+    sets = scenario.set_dict
+
+    if scenario.source_locations is not None:
+        instance.sources = Set(
+            initialize=sets['sources'], doc='Set of sources')
+
+    if scenario.sink_locations is not None:
+        instance.sinks = Set(initialize=sets['sinks'], doc='Set of sinks')

--- a/src/energiapy/model/sets/modes.py
+++ b/src/energiapy/model/sets/modes.py
@@ -1,0 +1,36 @@
+from ...components.scenario import Scenario
+from ...utils.scale_utils import scale_pyomo_set
+from pyomo.environ import ConcreteModel, Set
+
+def generate_production_mode_sets(instance: ConcreteModel, scenario: Scenario):
+    """generates production mode sets
+
+    Args:
+        instance (ConcreteModel): pyomo model
+        scenario (Scenario): energiapy scenario
+    """
+
+    sets = scenario.set_dict
+
+    instance.processes_segments = Set(
+        initialize=sets['processes_segments'], doc='Set of processes with PWL process segments')
+
+    instance.process_modes = Set(
+        scenario.set_dict['processes_full'], initialize=scenario.mode_dict, doc='Set of processes and thier modes')
+
+
+def generate_material_mode_sets(instance: ConcreteModel, scenario: Scenario):
+    """generates process material mode sets
+
+    Args:
+        instance (ConcreteModel): pyomo model
+        scenario (Scenario): energiapy scenario
+    """
+
+    sets = scenario.set_dict
+
+    instance.process_material_modes = Set(
+        initialize=sets['process_material_modes'], doc='Set of process and material combinations')
+
+    instance.material_modes = Set(
+        initialize=sets['material_modes'], doc='Set of material modes')

--- a/src/energiapy/model/sets/process_subsets.py
+++ b/src/energiapy/model/sets/process_subsets.py
@@ -1,0 +1,33 @@
+from ...components.scenario import Scenario
+from ...utils.scale_utils import scale_pyomo_set
+from pyomo.environ import ConcreteModel, Set
+
+def generate_process_subsets(instance: ConcreteModel, scenario: Scenario):
+    """generates process subsets
+
+    Args:
+        instance (ConcreteModel): pyomo model
+        scenario (Scenario): energiapy scenario
+    """
+
+    sets = scenario.set_dict
+
+    instance.processes_varying_capacity = Set(
+        initialize=sets['processes_varying_capacity'], doc='Set of processes with varying capacity')
+    instance.processes_certain_capacity = Set(
+        initialize=sets['processes_certain_capacity'], doc='Set of processes with certain capacity')
+    instance.processes_varying_expenditure = Set(
+        initialize=sets['processes_varying_expenditure'], doc='Set of processes with varying expenditure')
+    instance.processes_failure = Set(
+        initialize=sets['processes_failure'], doc='Set of processes which can fail')
+    instance.processes_materials = Set(initialize=sets['processes_materials'],
+                                       doc='Set of processes with material requirements')
+    instance.processes_storage = Set(
+        initialize=sets['processes_storage'], doc='Set of storage process')
+    instance.processes_multim = Set(
+        initialize=sets['processes_multim'], doc='Set of processes with multiple modes')
+    instance.processes_singlem = Set(
+        initialize=sets['processes_singlem'], doc='Set of processes with multiple modes')
+
+    instance.processes_uncertain_capacity = Set(initialize=sets['processes_uncertain_capacity'],
+                                                doc='Set of processes with uncertain capacity')

--- a/src/energiapy/model/sets/resource_subsets.py
+++ b/src/energiapy/model/sets/resource_subsets.py
@@ -1,0 +1,56 @@
+from ...components.scenario import Scenario
+from ...utils.scale_utils import scale_pyomo_set
+from pyomo.environ import ConcreteModel, Set
+
+
+def generate_resource_subsets(instance: ConcreteModel, scenario: Scenario):
+    """generates resource subsets
+
+    Args:
+        instance (ConcreteModel): pyomo model
+        scenario (Scenario): energiapy scenario
+    """
+
+    sets = scenario.set_dict
+
+    instance.resources_sell = Set(
+        initialize=sets['resources_sell'], doc='Set of dischargeable resources')
+    instance.resources_store = Set(
+        initialize=sets['resources_store'], doc='Set of storeable resources')
+    instance.resources_purch = Set(
+        initialize=sets['resources_purch'], doc='Set of purchased resources')
+
+    instance.resources_varying_price = Set(initialize=sets['resources_varying_price'],
+                                           doc='Set of resources with varying purchase price')
+
+    instance.resources_certain_price = Set(initialize=sets['resources_certain_price'],
+                                           doc='Set of resources with certain purchase price')
+
+    instance.resources_varying_availability = Set(initialize=sets['resources_varying_availability'],
+                                                  doc='Set of resources with varying purchase price')
+
+    instance.resources_certain_availability = Set(initialize=sets['resources_certain_availability'],
+                                                  doc='Set of resources with certain purchase price')
+
+    instance.resources_varying_revenue = Set(initialize=sets['resources_varying_revenue'],
+                                             doc='Set of resources with varying selling revenue')
+    instance.resources_certain_revenue = Set(initialize=sets['resources_certain_revenue'],
+                                             doc='Set of resources with certain selling revenue')
+    instance.resources_varying_demand = Set(initialize=sets['resources_varying_demand'],
+                                            doc='Set of resources with varying purchase price')
+    instance.resources_certain_demand = Set(initialize=sets['resources_certain_demand'],
+                                            doc='Set of resources with certain purchase price')
+    instance.resources_demand = Set(
+        initialize=sets['resources_demand'], doc='Set of resources with exact demand')
+
+    if scenario.transport_set is not None:
+        instance.resources_trans = Set(
+            initialize=sets['resources_trans'], doc='Set of transportable resources')
+
+    instance.resources_uncertain_price = Set(initialize=sets['resources_uncertain_price'],
+                                             doc='Set of resources with uncertain purchase price')
+    instance.resources_uncertain_revenue = Set(initialize=sets['resources_uncertain_revenue'],
+                                               doc='Set of resources with uncertain purchase revenue')
+
+    instance.resources_uncertain_demand = Set(initialize=sets['resources_uncertain_demand'],
+                                              doc='Set of resources with uncertain demand')

--- a/src/energiapy/model/sets/temporal.py
+++ b/src/energiapy/model/sets/temporal.py
@@ -1,0 +1,24 @@
+from ...components.scenario import Scenario
+from ...utils.scale_utils import scale_pyomo_set
+from pyomo.environ import ConcreteModel, Set
+
+
+def generate_temporal_sets(instance: ConcreteModel, scenario: Scenario):
+    """creates temporal sets
+    1. the parent set (planning horizon)
+    2. scales_network
+    3. scales_scheduling
+
+    Args:
+        instance (ConcreteModel): pyomo model
+        scenario (Scenario): energiapy scenario
+    """
+
+    instance.scales = Set(scenario.scales.list,
+                          initialize=scenario.scales.scale, doc='set of scales')
+
+    instance.scales_network = scale_pyomo_set(
+        instance=instance, scale_level=scenario.network_scale_level, doc='scale for network decisions')
+
+    instance.scales_scheduling = scale_pyomo_set(
+        instance=instance, scale_level=scenario.scheduling_scale_level, doc='scale for scheduling decisions')

--- a/src/energiapy/model/sets/transport_subsets.py
+++ b/src/energiapy/model/sets/transport_subsets.py
@@ -1,0 +1,41 @@
+from ...components.scenario import Scenario
+from ...utils.scale_utils import scale_pyomo_set
+from pyomo.environ import ConcreteModel, Set
+
+
+def generate_transport_subsets(instance: ConcreteModel, scenario: Scenario):
+    """generates transport subsets
+
+    Args:
+        instance (ConcreteModel): pyomo model
+        scenario (Scenario): energiapy scenario
+    """
+
+    sets = scenario.set_dict
+
+    instance.transports_varying_capacity = Set(
+        initialize=sets['transports_varying_capacity'], doc='Set of transports with varying capacity')
+    instance.transports_varying_capex = Set(
+        initialize=sets['transports_varying_capex'], doc='Set of transports with varying capex')
+    instance.transports_varying_fopex = Set(
+        initialize=sets['transports_varying_fopex'], doc='Set of transports with varying fopex')
+    instance.transports_varying_vopex = Set(
+        initialize=sets['transports_varying_vopex'], doc='Set of transports with varying vopex')
+
+    instance.transports_certain_capacity = Set(
+        initialize=sets['transports_certain_capacity'], doc='Set of transports with certain capacity')
+    instance.transports_certain_capex = Set(
+        initialize=sets['transports_certain_capex'], doc='Set of transports with certain capex')
+    instance.transports_certain_fopex = Set(
+        initialize=sets['transports_certain_fopex'], doc='Set of transports with certain fopex')
+    instance.transports_certain_vopex = Set(
+        initialize=sets['transports_certain_vopex'], doc='Set of transports with certain vopex')
+
+    instance.transports_uncertain_capacity = Set(
+        initialize=sets['transports_uncertain_capacity'], doc='Set of transports with uncertain capacity')
+    instance.transports_uncertain_capex = Set(
+        initialize=sets['transports_uncertain_capex'], doc='Set of transports with uncertain capex')
+    instance.transports_uncertain_fopex = Set(
+        initialize=sets['transports_uncertain_fopex'], doc='Set of transports with uncertain fopex')
+    instance.transports_uncertain_vopex = Set(
+        initialize=sets['transports_uncertain_vopex'], doc='Set of transports with uncertain vopex')


### PR DESCRIPTION
**1. Made a clear distinction between factor scales and scales for variables (decisions making)**

Location objects take variable factor data as inputs and corresponding factor scales need to be defined
These are limited to:
1. demand factor scale level 
2. price factor scale level
3. capacity factor scale level 
4. expenditure factor scale level 
5. availability factor scale level 
6. revenue factor scale level [NEW]

Scenario object takes scales for decision making:
1. network scale level 
2. scheduling scale level
3. demand scale level 

There are also checks to ensure that scales are defined with factors are declared, and to assert consistency between locations

This avoids the declaration of unnecessary scale level and inturn reduces the number of sets declared 

**2. Create a folder for sets and divided them**
They are now declared when needed in the formulate function
These sets include:
1. component sets
2. location subsets
3. mode sets (production and material)
4. process subsets
5. resource subsets
6. temporal 
7. transport subsets

**3. Applied the general constraint definition to more constraints**

**4. Fixed dual dict for multilocation LPs and made the generation of duals optional** 

